### PR TITLE
Attempt to simplify config

### DIFF
--- a/mlflow/_spark_autologging.py
+++ b/mlflow/_spark_autologging.py
@@ -241,7 +241,7 @@ class SparkAutologgingContext(RunContextProvider):
                 if info not in seen:
                     unique_infos.append(info)
                     seen.add(info)
-            if len(_table_infos) > 0:
+            if len(unique_infos) > 0:
                 tags = {
                     _SPARK_TABLE_INFO_TAG_NAME: "\n".join(
                         [_get_table_info_string(*info) for info in unique_infos]
@@ -249,5 +249,4 @@ class SparkAutologgingContext(RunContextProvider):
                 }
             else:
                 tags = {}
-            _table_infos = []
             return tags

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -694,12 +694,11 @@ def autolog(disable=False):  # pylint: disable=unused-argument
     attached. It should be called on the Spark driver, not on the executors (i.e. do not call
     this method within a function parallelized by Spark). This API requires Spark 3.0 or above.
 
-    Datasource information is logged under the current active MLflow run. If no active run
-    exists, datasource information is cached in memory & logged to the next-created active run
-    (but not to successive runs). Note that autologging of Spark ML (MLlib) models is not currently
-    supported via this API. Datasource-autologging is best-effort, meaning that if Spark is under
-    heavy load or MLflow logging fails for any reason (e.g., if the MLflow server is unavailable),
-    logging may be dropped.
+    Datasource information is cached in memory and logged to all subsequent MLflow runs,
+    including the active MLflow run (if one exists when the data is read). Note that autologging of
+    Spark ML (MLlib) models is not currently supported via this API. Datasource autologging is
+    best-effort, meaning that if Spark is under heavy load or MLflow logging fails for any reason
+    (e.g., if the MLflow server is unavailable), logging may be dropped.
 
     For any unexpected issues with autologging, check Spark driver and executor logs in addition
     to stderr & stdout generated from your MLflow code - datasource information is pulled from

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1347,7 +1347,7 @@ def autolog(
             autolog_fn = LIBRARY_TO_AUTOLOG_FN[module.__name__]
 
             # Only call integration's autolog function with `mlflow.autolog` configs
-            # if the integration's autolog function has not already been called.
+            # if the integration's autolog function has not already been called by the user.
             # Logic is as follows:
             # - if a previous_config exists, that means either `mlflow.autolog` or
             #   `mlflow.integration.autolog` was called.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1300,6 +1300,24 @@ def autolog(
                   'training_mse': 1.9721522630525295e-31}
         tags: {'estimator_class': 'sklearn.linear_model._base.LinearRegression',
                'estimator_name': 'LinearRegression'}
+
+    Note that framework-specific configurations set at any poing will
+    take precedence over any configurations set by this function. For example:
+
+    .. code-block:: python
+        mlflow.autolog(log_models=False, exclusive=True)
+        import sklearn
+
+    would enable autologging for `sklearn` with `log_models=False` and `exclusive=True`,
+    but
+
+    .. code-block:: python
+        mlflow.autolog(log_models=False, exclusive=True)
+        import sklearn
+        mlflow.sklearn.autolog(log_models=True)
+
+    would enable autologging for `sklearn` with `log_models=True` and `exclusive=False`,
+    the latter resulting from the default value for `exclusive` in `mlflow.sklearn.autolog`.
     """
     from mlflow import (
         tensorflow,

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1301,7 +1301,7 @@ def autolog(
         tags: {'estimator_class': 'sklearn.linear_model._base.LinearRegression',
                'estimator_name': 'LinearRegression'}
 
-    Note that framework-specific configurations set at any poing will
+    Note that framework-specific configurations set at any point will
     take precedence over any configurations set by this function. For example:
 
     .. code-block:: python

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -349,6 +349,7 @@ def autologging_integration(name):
             return _autolog(*args, **kwargs)
 
         wrapped_autolog = _update_wrapper_extended(autolog, _autolog)
+        wrapped_autolog.integration_name = name
         return wrapped_autolog
 
     return wrapper

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -194,18 +194,36 @@ def test_universal_autolog_makes_expected_event_logging_calls():
     assert {"disable": True, "exclusive": True}.items() <= call.call_kwargs.items()
 
 
+def test_autolog_obeys_disabled():
+    mlflow.autolog(disable=True)
+    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+    assert get_autologging_config("tensorflow", "disable")
+
+    mlflow.autolog()
+    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+    mlflow.autolog(disable=True)
+    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+    assert get_autologging_config("tensorflow", "disable")
+
+    mlflow.autolog(disable=False)
+    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+    assert not get_autologging_config("tensorflow", "disable", False)
+    mlflow.tensorflow.autolog(disable=True)
+    assert get_autologging_config("tensorflow", "disable")
+
+
 def test_autolog_success_message_obeys_disabled():
     with mock.patch("mlflow.tracking.fluent._logger.info") as autolog_logger_mock:
         mlflow.autolog(disable=True)
-        mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+        mlflow.utils.import_hooks.notify_module_loaded(sklearn)
         autolog_logger_mock.assert_not_called()
 
         mlflow.autolog()
-        mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+        mlflow.utils.import_hooks.notify_module_loaded(sklearn)
         autolog_logger_mock.assert_called()
 
         autolog_logger_mock.reset_mock()
 
         mlflow.autolog(disable=False)
-        mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+        mlflow.utils.import_hooks.notify_module_loaded(sklearn)
         autolog_logger_mock.assert_called()

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -196,34 +196,34 @@ def test_universal_autolog_makes_expected_event_logging_calls():
 
 def test_autolog_obeys_disabled():
     mlflow.autolog(disable=True)
-    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
-    assert get_autologging_config("tensorflow", "disable")
+    mlflow.utils.import_hooks.notify_module_loaded(sklearn)
+    assert get_autologging_config("sklearn", "disable")
 
     mlflow.autolog()
-    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+    mlflow.utils.import_hooks.notify_module_loaded(sklearn)
     mlflow.autolog(disable=True)
-    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
-    assert get_autologging_config("tensorflow", "disable")
+    mlflow.utils.import_hooks.notify_module_loaded(sklearn)
+    assert get_autologging_config("sklearn", "disable")
 
     mlflow.autolog(disable=False)
-    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
-    assert not get_autologging_config("tensorflow", "disable", False)
+    mlflow.utils.import_hooks.notify_module_loaded(sklearn)
+    assert not get_autologging_config("sklearn", "disable", False)
     mlflow.tensorflow.autolog(disable=True)
-    assert get_autologging_config("tensorflow", "disable")
+    assert get_autologging_config("sklearn", "disable")
 
 
 def test_autolog_success_message_obeys_disabled():
     with mock.patch("mlflow.tracking.fluent._logger.info") as autolog_logger_mock:
         mlflow.autolog(disable=True)
-        mlflow.utils.import_hooks.notify_module_loaded(sklearn)
+        mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
         autolog_logger_mock.assert_not_called()
 
         mlflow.autolog()
-        mlflow.utils.import_hooks.notify_module_loaded(sklearn)
+        mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
         autolog_logger_mock.assert_called()
 
         autolog_logger_mock.reset_mock()
 
         mlflow.autolog(disable=False)
-        mlflow.utils.import_hooks.notify_module_loaded(sklearn)
+        mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
         autolog_logger_mock.assert_called()


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
